### PR TITLE
Move shell script to Node.js and update README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 package-lock.json
+npm-debug.log
 build
 
 app/shows

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Directory structure:
 
 * `app/` houses the app and all the files needed.
 * `app/config` contains config files.
-* `app/css` contains css files that are used in Gallium.
-* `app/html` contains html files that are used in Gallium.
-* `app/js` contains javascript files that are used in Gallium.
+* `app/css` contains CSS files that are used in Gallium.
+* `app/html` contains HTML files that are used in Gallium.
+* `app/js` contains JavaScript files that are used in Gallium.
 * `app/img` contains image files that are used in Gallium.
 
 ## Pre-requisites
@@ -18,16 +18,16 @@ Directory structure:
 ## Dev Environment Setup and Running
 
 1. Run `npm install` from the root directory
-2. Run `./setupRepo` from the root directory
+2. Run `node setupRepo.js` from the root directory
 3. Run `npm start`
 
 ## Application Packaging
 
 1. Run `npm install` from the root directory
-2. Run `./setupRepo` from the root directory
+2. Run `node setupRepo.js` from the root directory
 3. Run `npm run-script package`
 
-NOTE: If you are on Mac or Linux you need wine installed to package a Windows Build.
+NOTE: If you are on Mac or Linux you need Wine installed to package a Windows Build.
 
 ## Scripts
 
@@ -41,7 +41,7 @@ NOTE: If you are on Mac or Linux you need wine installed to package a Windows Bu
 
 ## Styles
 
-We are using a modified version of the airbnb javascript style guide. One major change from the airbnb guide is that we are using 4 space indents instead of 2. Run `npm run-script lint` to lint our code and `npm run-script lint-fix` to fix common errors. So error might need to be done fixed manually.
+We are using a modified version of the [Airbnb JavaScript Style Guide](https://github.com/airbnb/javascript). One major change from the Airbnb guide is that we are using 4 space indents instead of 2. Run `npm run-script lint` to lint our code and `npm run-script lint-fix` to fix common errors. Some errors might need to be fixed manually.
 
 ## Authors
 

--- a/package.json
+++ b/package.json
@@ -25,5 +25,7 @@
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.14.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "fs-extra": "^7.0.0"
+  }
 }

--- a/setupRepo.js
+++ b/setupRepo.js
@@ -1,0 +1,9 @@
+const fse = require('fs-extra');
+const path = require('path');
+
+let repoRoot = __dirname;
+
+// removes everything in directory but leaves direcory intact OR creates
+// directory if it doesn't exist
+fse.emptyDirSync(path.join(repoRoot, "/build"));
+fse.emptyDirSync(path.join(repoRoot, "/app/shows"));

--- a/setupRepo.sh
+++ b/setupRepo.sh
@@ -1,9 +1,0 @@
-#!/bin/bash -eu
-REPO_ROOT=$(cd "`dirname "$0"`" && pwd)
-PARENT_DIR=$(cd "$REPO_ROOT/.." && pwd)
-
-rm "-rf" "${REPO_ROOT}/build"
-rm "-rf" "${REPO_ROOT}/app/shows"
-
-mkdir "${REPO_ROOT}/build"
-mkdir "${REPO_ROOT}/app/shows"


### PR DESCRIPTION
The conversion of a shell script to a Node.js script is to make sure
that everything can be run on all operating systems.  The .gitignore was
updated to reflect the new commands needed to be run.  More links and
some grammar/formatting changes was also added to the README.

Resolves issue #3 