### PR TITLE
iss46 - Fix add show button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ npm-debug.log
 build
 dist
 app/shows
+app/config/shows.json

--- a/app/config/shows.json
+++ b/app/config/shows.json
@@ -1,9 +1,4 @@
 {
   "activeShow": "",
-  "shows": [
-    "app/shows/test",
-    "app/shows/123",
-    "app/shows/1234",
-    "app/shows/testing the test software"
-  ]
+  "shows": []
 }

--- a/app/html/addShow.html
+++ b/app/html/addShow.html
@@ -7,11 +7,15 @@
 <body>
     <input class="credentialFormInput" style="width:69%" placeholder="Show Name" id="showName" type="text">
     <button id='submit'>OK</button>
+    <button id='cancel'>Cancel</button>
 </body>
     <script type="text/javascript" src="../js/addShow.js"></script>
     <script>
-        const button = document.getElementById('submit');
-        button.onclick = function () {addNewShow()};
+        document.getElementById('showName').focus();
+        const submitButton = document.getElementById('submit');
+        const cancelButton = document.getElementById('cancel');
+        submitButton.onclick = function () {addNewShow()};
+        cancelButton.onclick = function () {returnToShows()};
 
         window.addEventListener("keydown", function (event) {
             if (event.defaultPrevented) {

--- a/app/html/shows.html
+++ b/app/html/shows.html
@@ -25,50 +25,5 @@
     <button id='addShow'>Add Show</button>
 </body>
     <script type="text/javascript" src="../js/addShow.js"></script>
-    <script>
-        const button = document.getElementById('addShow');
-        button.onclick = function () {
-            popWindow();
-        };
-
-        var fs = parent.require('fs');
-        var path = parent.require('path');
-
-        var appConfigPath = path.join(parent.__dirname, './config/shows.json');
-        var appConfig = JSON.parse(fs.readFileSync(appConfigPath));
-
-        var activeShow = appConfig.activeShow;
-        var shows = appConfig.shows;
-        var table = document.getElementById('tableBody');
-        if (JSON.stringify(shows) === JSON.stringify([])) {
-            document.getElementById("noShows").style.display = "block";
-        } else {
-            document.getElementById('table').style.display = "block";
-
-            for(i in shows){
-                if (shows[i]) {
-                    var tableItem = document.createElement('tr');
-                    tableItem.onmousedown = function () {
-                        onShowClick(shows[i]);
-                    }
-                    var showName = document.createElement('td');
-                    showName.innerText = shows[i].split(path.sep)[2];
-                    tableItem.appendChild(showName);
-                    table.appendChild(tableItem);
-                }
-            } 
-        }
-
-        function onShowClick(newActiveShow) {
-            console.log('here')
-            var appConfigPath = path.join(parent.__dirname, './config/shows.json');
-            var appConfig = JSON.parse(fs.readFileSync(appConfigPath));
-            var activeShow = appConfig.activeShow;
-            activeShow = newActiveShow;
-            fs.writeFileSync(appConfigPath, JSON.stringify(appConfig, null, 2));
-            parent.document.getElementById("frame").src = "html/show.html"
-        }
-        
-
-    </script>
+    <script type="text/javascript" src="../js/shows.js"></script>
 </html>

--- a/app/index.html
+++ b/app/index.html
@@ -33,6 +33,7 @@
 
 
 </body>
+<script type="text/javascript" src="../setupRepo.js"></script>
 <script>
     var frame = document.getElementById("frame");
 
@@ -47,5 +48,4 @@
     }
 
 </script>
-
 </html>

--- a/app/js/addShow.js
+++ b/app/js/addShow.js
@@ -1,39 +1,39 @@
 const parent = window.parent;
-const fs = parent.require('fs');
+const fse = parent.require('fs-extra');
 const path = parent.require('path');
-const Win = parent.require('electron').remote.BrowserWindow;
 
-function popWindow() {
-    const Popup = new Win({ width: 600, height: 400 });
-    Popup.loadFile('./app/html/addShow.html');
-}
-
-function closePopupWindow() {
-    parent.require('electron').remote.getCurrentWindow().close();
+function returnToShows() {
+    window.parent.document.getElementById('frame').src = './html/shows.html';
 }
 
 function addShowToConfig(showPath) {
-    const appConfigPath = path.join(path.resolve(), '../config/shows.json');
-    const data = JSON.parse(fs.readFileSync(appConfigPath));
+    const appConfigPath = path.join(path.resolve(), 'app/config/shows.json');
+    const data = JSON.parse(fse.readFileSync(appConfigPath));
+
     if (data) {
         const shows = data.shows;
         shows.push(showPath);
-        fs.writeFileSync(appConfigPath, JSON.stringify(data, null, 2));
+        fse.writeFileSync(appConfigPath, JSON.stringify(data, null, 2));
     }
 }
 
 function addNewShow() {
     const inputText = document.getElementById('showName').value;
-    const showPath = path.join('./app/shows', inputText);
+    const showsDir = path.resolve('app', 'shows');
+
+    const showPath = path.join(showsDir, inputText);
+
+    // path.join makes Windows path correct
     const emptyShowPath = path.join('./app/config/emptyShow.json');
 
-    if (fs.existsSync(showPath)) {
+    if (fse.existsSync(showPath)) {
         alert(`Yo, show ${inputText} already exists`);
     } else {
-        fs.mkdirSync(showPath);
+        fse.mkdirSync(showPath);
         alert(`New show ${inputText} added`);
-        fs.copyFileSync(emptyShowPath, path.join(showPath, 'show.json'));
+        fse.copyFileSync(emptyShowPath, path.join(showPath, 'show.json'));
         addShowToConfig(showPath);
     }
-    closePopupWindow();
+
+    returnToShows();
 }

--- a/app/js/shows.js
+++ b/app/js/shows.js
@@ -1,0 +1,36 @@
+const button = document.getElementById('addShow');
+
+button.onclick = function changePageSource() {
+    window.parent.document.getElementById('frame').src = './html/addShow.html';
+};
+
+const appConfigPath = path.resolve('app/config/shows.json');
+const appConfig = JSON.parse(fse.readFileSync(appConfigPath));
+let activeShow = appConfig.activeShow;
+const shows = appConfig.shows;
+const table = document.getElementById('tableBody');
+
+function onShowClick(newActiveShow) {
+    activeShow = newActiveShow;
+    fse.writeFileSync(appConfigPath, JSON.stringify(appConfig, null, 2));
+    window.parent.document.getElementById('frame').src = 'html/show.html';
+}
+
+if (JSON.stringify(shows) === JSON.stringify([])) {
+    document.getElementById('noShows').style.display = 'block';
+} else {
+    document.getElementById('table').style.display = 'block';
+
+    for (let i = 0; i < shows.length; i += 1) {
+        if (shows[i]) {
+            const tableItem = document.createElement('tr');
+            tableItem.onmousedown = function writeShowToConfigFile() {
+                onShowClick(shows[i]);
+            };
+            const showName = document.createElement('td');
+            showName.innerText = shows[i].split('app')[1].split(path.sep)[2];
+            tableItem.appendChild(showName);
+            table.appendChild(tableItem);
+        }
+    }
+}

--- a/setupRepo.js
+++ b/setupRepo.js
@@ -1,8 +1,21 @@
 const fse = require('fs-extra');
 const path = require('path');
 
-const repoRoot = __dirname;
+/*
+ * Ensures that shows.json exists whether run to set up the repo or when the
+ * app is started.  If the file is not present, create a new blank shows.json.
+ */
+
+const currentDir = path.resolve();
+const repoRoot = currentDir.split('app')[0];
 
 // removes everything in directory but leaves direcory intact OR creates
 // directory if it doesn't exist
-fse.emptyDirSync(path.join(repoRoot, '/app/shows'));
+fse.ensureDirSync(path.join(repoRoot, '/app/shows'));
+
+const showsJsonPath = path.join(repoRoot, '/app/config/shows.json');
+const data = JSON.stringify({ activeShow: '', shows: [] }, null, 2);
+
+if (!fse.existsSync(showsJsonPath)) {
+    fse.writeFileSync(showsJsonPath, data);
+}


### PR DESCRIPTION
* Make add show button work again
* Reload Shows page after adding a show name
* Remove popup window
* Ensure that the `app/shows` directory exists when adding a show by
running setupRepo.js on app start
* Add cancel button to go back to Shows page without adding show name
* Modify .gitignore to ignore `app/config/shows.json`
* Extract Javascript in `shows.html` to `shows.js`

Closes #46