### PR TITLE
#94 Remove hardcoded patching url

### DIFF
--- a/app/css/style.css
+++ b/app/css/style.css
@@ -40,7 +40,7 @@ input {
     padding-top: 20px;
     background-color: #111;
 }
-  
+
 .sideNavIFrameWrapper{
     display: flex;
 }
@@ -114,7 +114,7 @@ input {
 
 .headertext {
     display: inline-block; /* or block */
-    font-size: 30px; 
+    font-size: 30px;
     text-align: center;
     background-color: #247dff;
     padding: 20px;
@@ -147,7 +147,7 @@ button:disabled {
     justify-content: center; /* horizontal centering */
     align-items: center; /* vertical centering */
     height: 100vh;
-    margin: 0; 
+    margin: 0;
     overflow-y: hidden;
 }
 
@@ -232,3 +232,29 @@ select {
     position: absolute;
     z-index: 10;
 }
+
+.flex-container {
+    display: flex;
+    align-items: center;
+}
+
+.flex-container div {
+    margin: 10px;
+}
+
+.invisible {
+    display: none;
+}
+
+.patchingUrl {
+    width: 90%;
+}
+
+#urlRow, #urlModification {
+    flex: 0 0 auto;
+}
+
+#urlInput {
+    flex: 1 1 auto;
+}
+

--- a/app/html/show.html
+++ b/app/html/show.html
@@ -27,24 +27,40 @@
     <br><br><br><br>
     <button id='patchShow'>Patch Show</button>
     <label for="patchShow" name="patchStatus" id="patchLabel">Ready!</label>
+
+    <div class="flex-container">
+        <div id='urlRow'>
+            <p>Google Script Patching URL:</p>
+        </div>
+        <div id='urlInput'>
+            <input id="patchingUrlInput" class="invisible patchingUrl"></input>
+            <span id="patchingUrlDisplay" class="patchingUrl"></input>
+        </div>
+        <div id='urlModification'>
+            <button id="editUrl">Edit</button>
+            <button id="saveUrl" class='invisible'>Save</button>
+            <button id="cancelUrl" class='invisible'>Cancel</button>
+        </div>
+    </div>
 </body>
-    <script type="text/javascript" src="../js/addShow.js"></script>
-    <script>
-        const addElementButton = document.getElementById('addElement');
-        const iframe = window.parent.document.getElementById('frame');
-        const header = document.getElementById('header');
-        const patchButton = document.getElementById('patchShow');
 
-        addElementButton.onclick = function () {addNewElement()};
-        patchButton.onclick = function () {patchShow()};
+<script type="text/javascript" src="../js/addShow.js"></script>
+<script>
+    const iframe           = window.parent.document.getElementById('frame');
+    const addElementButton = document.getElementById('addElement');
+    const header           = document.getElementById('header');
+    const patchButton      = document.getElementById('patchShow');
 
-        var onlyShowName = iframe.value.split(path.sep);
-        onlyShowName = iframe.value.split(path.sep)[onlyShowName.length - 1];
-        header.innerText = onlyShowName;
+    addElementButton.onclick = function () {addNewElement()};
+    patchButton.onclick      = function () {patchShow()};
 
-    </script>
-    <script type="text/javascript" src="../js/patchShow.js"></script>
-    <script type="text/javascript" src="../js/sendDMX.js"></script>
-    <script type="text/javascript" src="../js/show.js"></script>
+    var onlyShowName = iframe.value.split(path.sep);
+    onlyShowName     = iframe.value.split(path.sep)[onlyShowName.length - 1];
+    header.innerText = onlyShowName;
+</script>
+<script type="text/javascript" src="../js/patchShow.js"></script>
+<script type="text/javascript" src="../js/sendDMX.js"></script>
+<script type="text/javascript" src="../js/show.js"></script>
+<script type="text/javascript" src="../js/modifyPatchUrl.js"></script>
 
 </html>

--- a/app/js/addShow.js
+++ b/app/js/addShow.js
@@ -35,13 +35,20 @@ function addNewShow() {
         alert(`Yo, show '${showName}' already exists`);
     } else {
         fse.mkdirSync(showPath);
-        alert(`New show '${showName}' added`);
         fse.copyFileSync(emptyShowPath, path.join(showPath, 'show.json'));
+
         const showJson = JSON.parse(fse.readFileSync(path.join(showPath, 'show.json')));
+
+        // set information in the JSON file used as the show's settings
         showJson.Name = `${showName}`;
+        showJson.GoogleScriptUrl = '';
+
         fse.writeFileSync(path.join(showPath, 'show.json'), JSON.stringify(showJson, null, 2));
+
         addShowToConfig(showPath);
         document.getElementById('validName').style.display = 'table';
+
+        alert(`New show '${showName}' added`);
     }
 }
 

--- a/app/js/modifyPatchUrl.js
+++ b/app/js/modifyPatchUrl.js
@@ -1,0 +1,74 @@
+// const fse = parent.require('fs-extra');
+// const path = parent.require('path');
+
+const editButton = document.getElementById('editUrl');
+const saveButton = document.getElementById('saveUrl');
+const cancelButton = document.getElementById('cancelUrl');
+const display = document.getElementById('patchingUrlDisplay');
+const input = document.getElementById('patchingUrlInput');
+
+// anonymous namespace
+{
+
+// show settings file
+const showPath = iframe.value;
+const settingsFile = path.join(showPath, 'show.json');
+
+let url = '';
+
+// Make the url editible. Put the text into an input box where a new value can
+// be typed in. Show the appropriate buttons
+editButton.addEventListener('click', () => {
+    display.classList.add('invisible');
+
+    input.value = url;
+    input.classList.remove('invisible');
+
+    editButton.classList.add('invisible');
+    saveButton.classList.remove('invisible');
+    cancelButton.classList.remove('invisible');
+});
+
+// Get the text value out of the input and save it to the settings file
+saveButton.addEventListener('click', () => {
+    const data = JSON.parse(fse.readFileSync(settingsFile));
+    data['GoogleScriptUrl'] = input.value;
+
+    fse.writeFileSync(settingsFile, JSON.stringify(data, null, 2));
+
+    refreshUrl();
+    showDisplay();
+});
+
+// Remove the text input box and restore the value of the previous url. Does
+// not save any input
+cancelButton.addEventListener('click', () => {
+    refreshUrl();
+    showDisplay();
+});
+
+// Ensure the displayed url value is up-to-date with the value in the settings
+// file
+function refreshUrl() {
+    // parse JSON data out of config file
+    const data = JSON.parse(fse.readFileSync(settingsFile));
+    url = data['GoogleScriptUrl'];
+
+    display.innerText = url;
+}
+
+// Show the elements that are necessary for displaying a show's url. Only
+// certain buttons should be shown
+function showDisplay() {
+    display.classList.remove('invisible');
+    input.classList.add('invisible');
+
+    editButton.classList.remove('invisible');
+    saveButton.classList.add('invisible');
+    cancelButton.classList.add('invisible');
+}
+
+// set the displayed value when the page is loaded
+refreshUrl();
+
+} // anonymous namespace

--- a/app/js/patchShow.js
+++ b/app/js/patchShow.js
@@ -73,9 +73,8 @@ function applyPatchToShow() {
 function getUrl() {
     const showJsonPath = path.join(showPath, 'show.json');
     const data = JSON.parse(fse.readFileSync(showJsonPath));
-    const url = data.GoogleScriptUrl;
 
-    return url;
+    return data.GoogleScriptUrl;
 }
 
 // Uses promises to ensure that things happen in a specific order.


### PR DESCRIPTION
* Add elements to `show.html` to display the current show's patching URL
* Add some CSS to align elements displaying the URL
* Reorder `addShow.js` logic for creating a show
* Remove hardcoded url from `patchShow.js` in favor of function that reads
URL from the show's settings file
* Add `modifyPatchUrl.js` to handle UI elements displaying URL and reading
and writing the URL value to and from the show's settings file

Closes #94 