### PR TITLE
Iss88 - When Outputting to DMX with no DMX selected, show error

### DIFF
--- a/app/js/dmx.js
+++ b/app/js/dmx.js
@@ -28,7 +28,13 @@ function getIntFromElementById(id, defaultVal) {
 // Sets all channels to be on or off
 // value is an int in range [0, 255]
 function setAll(value) {
-    parent.parent.universe.updateAll(value);
+    try {
+        parent.parent.universe.updateAll(value);
+    } catch (error) {
+        alert('Error: No DMX device selected')
+        isFading = false
+    }
+    
 }
 
 // Updates the current fade amount. Only changes if isFading is set
@@ -61,7 +67,12 @@ function setRange(channelStart, channelEnd, value) {
         // DMX is 1-indexed. This should be the only place where the +1 is added
         channels[i] = value;
     }
-    parent.parent.universe.update(channels);
+    try {
+        parent.parent.universe.update(channels);
+    } catch (error) {
+        alert('Error: No DMX device selected')
+    }
+    
 }
 
 

--- a/app/js/dmx.js
+++ b/app/js/dmx.js
@@ -31,10 +31,9 @@ function setAll(value) {
     try {
         parent.parent.universe.updateAll(value);
     } catch (error) {
-        alert('Error: No DMX device selected')
-        isFading = false
+        alert('Error: No DMX device selected');
+        isFading = false;
     }
-    
 }
 
 // Updates the current fade amount. Only changes if isFading is set
@@ -70,9 +69,8 @@ function setRange(channelStart, channelEnd, value) {
     try {
         parent.parent.universe.update(channels);
     } catch (error) {
-        alert('Error: No DMX device selected')
+        alert('Error: No DMX device selected');
     }
-    
 }
 
 


### PR DESCRIPTION
Added try-catch blocks to catch the error and display an error alert
For setALL, set isFading to false to avoid infinite alert loop