### PR TITLE
Iss120 Add checkboxes to select which show elements to play

### DIFF
--- a/app/css/style.css
+++ b/app/css/style.css
@@ -286,3 +286,6 @@ button:disabled {
     flex: 1 1 auto;
 }
 
+.greyout {
+    opacity: 0.2;
+}

--- a/app/html/show.html
+++ b/app/html/show.html
@@ -13,8 +13,9 @@
         <thead>
             <caption>Show Files:</caption>
             <tr>
-                <th onclick="sortTableCheckbox(0)">Element</th>
-                <th onclick="sortTable(1)">Audio</th>
+                <th>Should Play?</th>
+                <th>Element</th>
+                <th>Audio</th>
             </tr>
         </thead>
         <tbody id="tableBody">


### PR DESCRIPTION
* Add checkbox for each show element when in the table showing a show's
elements. A checked box means the element should play. An unchecked element
means the element should not play. This new checkbox gets its own column
in each table row.
* Grey out the corresponding row in the table when the should play checkbox
is not checked.
* Only push show elements that have check marks in their row into the queue
to be played

Closes #120 