### PR TITLE
Adding gallium-test-files as submodule using relative url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "test/gallium-test-files"]
+	path = test/gallium-test-files
+	url = ../gallium-test-files.git


### PR DESCRIPTION
Fixes #136. Submodule added. Using a relative URL based on [StackOverflow ](https://stackoverflow.com/a/44630028) so that clones with HTTPS and SSH both work.